### PR TITLE
Default grep groupname

### DIFF
--- a/lib/repack-group.js
+++ b/lib/repack-group.js
@@ -1,5 +1,6 @@
 const repackTeacher = require('./repack-teacher')
 const shortenSchoolName = require('./shorten-school-name')
+const repackLanguage = require('./repack-languagecodes')
 
 module.exports = (group) => {
   const { grep, id, type, groupId, name, description, schoolId, schoolName, students, teachers } = group
@@ -36,16 +37,8 @@ module.exports = (group) => {
       grep: {
         kode,
         dataUrl,
-        tittel: {
-          default: tittel.default,
-          nob: tittel.nob,
-          nno: tittel.nno
-        },
-        kortform: {
-          default: kortform.default,
-          nob: kortform.nob,
-          nno: kortform.nno
-        }
+        tittel: repackLanguage(tittel),
+        kortform: repackLanguage(kortform)
       }
     }
   }
@@ -61,10 +54,8 @@ module.exports = (group) => {
     ...groupInfo,
     grep: {
       kode,
-      kortform: {
-        default: description,
-        nob: description
-      }
+      tittel: repackLanguage({ default: descriptionName }),
+      kortform: repackLanguage({ default: descriptionName })
     }
   }
 }

--- a/lib/repack-languagecodes.js
+++ b/lib/repack-languagecodes.js
@@ -1,0 +1,24 @@
+/**
+ * Takes an input object with language codes and returns it with correct codes following the ISO-639-1 standard.
+ * If a `default` value is passed, this is used whenever a value is missing from the input.
+ *
+ * @example
+ *  Input: {
+ *    nob: 'Hei!',
+ *    eng: 'Hello!',
+ *    default: 'Standard hallo!'
+ *  }
+ *
+ *  Outputs: {
+ *    nb: 'Hei!',
+ *    nn: 'Standard hallo!',
+ *    en: 'Hello!'
+ *  }
+ *
+ * @param {Object} input The object that should be repacked and returned with correct language codes
+ */
+module.exports = (input) => ({
+  nb: input.nb || input.nob || input.default || null,
+  nn: input.nn || input.nno || input.default || null,
+  en: input.en || input.eng || input.default || null
+})

--- a/lib/repack-student-utdprog.js
+++ b/lib/repack-student-utdprog.js
@@ -1,3 +1,5 @@
+const repackLanguage = require('./repack-languagecodes')
+
 module.exports = (utdprog) => {
   const { grep, id, name } = utdprog
 
@@ -10,16 +12,8 @@ module.exports = (utdprog) => {
     return {
       kode,
       type,
-      tittel: {
-        default: tittel.default,
-        nob: tittel.nob,
-        nno: tittel.nno
-      },
-      kortform: {
-        default: kortform.default,
-        nob: kortform.nob,
-        nno: kortform.nno
-      }
+      tittel: repackLanguage(tittel),
+      kortform: repackLanguage(kortform)
     }
   }
 
@@ -31,9 +25,7 @@ module.exports = (utdprog) => {
   return {
     kode,
     type: 'Ukjent',
-    kortform: {
-      default: name,
-      nob: name
-    }
+    tittel: repackLanguage({ default: name }),
+    kortform: repackLanguage({ default: name })
   }
 }


### PR DESCRIPTION
- Henter ut fagnavnet fra Extens-standarden i tilfeller hvor vi ikke får treff i GREP. Eks:
  - `Undervisningsgruppa 3PBF/NOR1212H20V21 i Norsk sidemål, skriftlig ved Kompetansebyggeren` => `Norsk sidemål, skriftlig`
  - `Undervisningsgruppa 1TAF/201ENG1007 i Engelsk ved Færder videregående skole` => `Engelsk`
- Ny metode som pakker om språk til [ISO-369-1](https://no.wikipedia.org/wiki/Liste_over_ISO_639-1-koder)-format (må oppdateres i frontend mock også før merge)