### PR TITLE
Fikser undefined mobilnummer

### DIFF
--- a/lib/repack-teacher.js
+++ b/lib/repack-teacher.js
@@ -6,8 +6,8 @@ module.exports = (teacher, removeGroups) => {
     lastName: teacher.lastName || teacher.familyName,
     fullName: teacher.fullName,
     username: teacher.username,
-    mail: teacher.email,
-    mobile: `${teacher.phone}`,
+    mail: teacher.email || '',
+    mobile: `${teacher.phone || ''}`,
 
     isContactTeacher: teacher.contactTeacher !== null ? teacher.contactTeacher : undefined,
 


### PR DESCRIPTION
Fikser så mobilnummer ikke blir `undefined` på lærerobjektet om det ikke er angitt i PIFU API